### PR TITLE
Add code for installing ZIPs directly via the app

### DIFF
--- a/app/src/main/java/de/robv/android/xposed/installer/installation/InstallCallback.java
+++ b/app/src/main/java/de/robv/android/xposed/installer/installation/InstallCallback.java
@@ -1,0 +1,23 @@
+package de.robv.android.xposed.installer.installation;
+
+import eu.chainfire.libsuperuser.Shell;
+
+public interface InstallCallback {
+    void onStarted();
+    void onLine(String line);
+    void onErrorLine(String line);
+    void onDone();
+    void onError(int exitCode, String error);
+
+    int OK = 0;
+
+    // SU errors
+    int ERROR_TIMEOUT = Shell.OnCommandResultListener.WATCHDOG_EXIT;
+    int ERROR_SHELL_DIED = Shell.OnCommandResultListener.SHELL_DIED;
+    int ERROR_EXEC_FAILED = Shell.OnCommandResultListener.SHELL_EXEC_FAILED;
+    int ERROR_WRONG_UID = Shell.OnCommandResultListener.SHELL_WRONG_UID;
+
+    // ZIP errors
+    int ERROR_INVALID_ZIP = -100;
+    int ERROR_NOT_FLASHABLE_IN_APP = -101;
+}

--- a/app/src/main/java/de/robv/android/xposed/installer/installation/InstallDirect.java
+++ b/app/src/main/java/de/robv/android/xposed/installer/installation/InstallDirect.java
@@ -1,0 +1,129 @@
+package de.robv.android.xposed.installer.installation;
+
+import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import de.robv.android.xposed.installer.XposedApp;
+import de.robv.android.xposed.installer.util.AssetUtil;
+import de.robv.android.xposed.installer.util.InstallZipUtil;
+import eu.chainfire.libsuperuser.Shell;
+
+import static de.robv.android.xposed.installer.util.InstallZipUtil.closeSilently;
+import static de.robv.android.xposed.installer.util.InstallZipUtil.triggerError;
+
+public final class InstallDirect {
+    public static void install(String zipPath, InstallCallback callback, boolean systemless) {
+        // Open the ZIP file.
+        ZipFile zip;
+        try {
+            zip = new ZipFile(zipPath);
+        } catch (IOException e) {
+            Log.e(XposedApp.TAG, "Could not open ZIP file", e);
+            triggerError(callback, InstallCallback.ERROR_INVALID_ZIP);
+            return;
+        }
+
+        // Do some checks.
+        InstallZipUtil.ZipCheckResult zipCheck = InstallZipUtil.checkZip(zip);
+        if (!zipCheck.isValidZip()) {
+            triggerError(callback, InstallCallback.ERROR_INVALID_ZIP);
+            closeSilently(zip);
+            return;
+        } else if (!zipCheck.isFlashableInApp()) {
+            triggerError(callback, InstallCallback.ERROR_NOT_FLASHABLE_IN_APP);
+            closeSilently(zip);
+            return;
+        }
+
+        // Extract update-binary.
+        ZipEntry entry = zip.getEntry("META-INF/com/google/android/update-binary");
+        File updateBinaryFile = new File(XposedApp.getInstance().getCacheDir(), "update-binary");
+        try {
+            AssetUtil.writeStreamToFile(zip.getInputStream(entry), updateBinaryFile, 0700);
+        } catch (IOException e) {
+            Log.e(XposedApp.TAG, "Could not extract update-binary", e);
+            triggerError(callback, InstallCallback.ERROR_INVALID_ZIP);
+            return;
+        } finally {
+            closeSilently(zip);
+        }
+
+        // Execute the flash commands.
+        Shell.Builder builder = new Shell.Builder()
+                .useSU()
+                .setOnSTDERRLineListener(new StderrListener(callback))
+                .addEnvironment("NO_UIPRINT", "1");
+
+        if (systemless) {
+            builder.addEnvironment("SYSTEMLESS", "1");
+        }
+
+        Shell.Interactive shell = builder.open(new OpenListener(callback));
+        shell.addCommand(updateBinaryFile.getAbsolutePath() + " 2 1 " + zipPath, 0, new StdoutListener(callback));
+        shell.addCommand("exit");
+    }
+
+    private static class OpenListener implements Shell.OnCommandResultListener {
+        private InstallCallback callback;
+
+        public OpenListener(InstallCallback callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public void onCommandResult(int commandCode, int exitCode, List<String> output) {
+            if (exitCode == SHELL_RUNNING) {
+                callback.onStarted();
+            } else {
+                triggerError(callback, exitCode);
+            }
+        }
+    }
+
+    private static class StdoutListener implements Shell.OnCommandLineListener {
+        private InstallCallback callback;
+
+        public StdoutListener(InstallCallback callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public void onLine(String line) {
+            callback.onLine(line);
+        }
+
+        @Override
+        public void onCommandResult(int commandCode, int exitCode) {
+            if (exitCode == InstallCallback.OK) {
+                callback.onDone();
+            } else {
+                triggerError(callback, exitCode);
+            }
+        }
+    }
+
+    private static class StderrListener implements Shell.OnCommandLineListener {
+        private InstallCallback callback;
+
+        public StderrListener(InstallCallback callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public void onLine(String line) {
+            callback.onErrorLine(line);
+        }
+
+        @Override
+        public void onCommandResult(int commandCode, int exitCode) {
+            // Not called for STDERR listener.
+        }
+    }
+
+    private InstallDirect() {}
+}

--- a/app/src/main/java/de/robv/android/xposed/installer/util/AssetUtil.java
+++ b/app/src/main/java/de/robv/android/xposed/installer/util/AssetUtil.java
@@ -58,18 +58,7 @@ public class AssetUtil {
             if (assets == null)
                 assets = XposedApp.getInstance().getAssets();
             InputStream in = assets.open(assetName);
-            FileOutputStream out = new FileOutputStream(targetFile);
-
-            byte[] buffer = new byte[1024];
-            int len;
-            while ((len = in.read(buffer)) > 0) {
-                out.write(buffer, 0, len);
-            }
-            in.close();
-            out.close();
-
-            FileUtils.setPermissions(targetFile.getAbsolutePath(), mode, -1, -1);
-
+            writeStreamToFile(in, targetFile, mode);;
             return targetFile;
         } catch (IOException e) {
             Log.e(XposedApp.TAG, "AssetUtil -> could not extract asset", e);
@@ -78,6 +67,20 @@ public class AssetUtil {
 
             return null;
         }
+    }
+
+    public static void writeStreamToFile(InputStream in, File targetFile, int mode) throws IOException {
+        FileOutputStream out = new FileOutputStream(targetFile);
+
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = in.read(buffer)) > 0) {
+            out.write(buffer, 0, len);
+        }
+        in.close();
+        out.close();
+
+        FileUtils.setPermissions(targetFile.getAbsolutePath(), mode, -1, -1);
     }
 
     public synchronized static void extractBusybox() {

--- a/app/src/main/java/de/robv/android/xposed/installer/util/InstallZipUtil.java
+++ b/app/src/main/java/de/robv/android/xposed/installer/util/InstallZipUtil.java
@@ -1,0 +1,88 @@
+package de.robv.android.xposed.installer.util;
+
+import java.io.IOException;
+import java.util.zip.ZipFile;
+
+import de.robv.android.xposed.installer.installation.InstallCallback;
+
+public final class InstallZipUtil {
+    public static class ZipCheckResult {
+        private boolean mValidZip = false;
+        private boolean mFlashableInApp = false;
+
+        public boolean isValidZip() {
+            return mValidZip;
+        }
+
+        public boolean isFlashableInApp() {
+            return mFlashableInApp;
+        }
+    }
+
+    public static ZipCheckResult checkZip(String zipPath) {
+        ZipFile zip;
+        try {
+            zip = new ZipFile(zipPath);
+        } catch (IOException e) {
+            return new ZipCheckResult();
+        }
+
+        ZipCheckResult result = checkZip(zip);
+        closeSilently(zip);
+        return result;
+    }
+
+    public static ZipCheckResult checkZip(ZipFile zip) {
+        ZipCheckResult result = new ZipCheckResult();
+
+        // Check for update-binary.
+        if (zip.getEntry("META-INF/com/google/android/update-binary") == null) {
+            return result;
+        }
+
+        result.mValidZip = true;
+
+        // Check whether the file can be flashed directly in the app.
+        if (zip.getEntry("META-INF/com/google/android/flash-script.sh") != null) {
+            result.mFlashableInApp = true;
+        }
+
+        return result;
+    }
+
+    public static String messageForError(int code) {
+        // TODO make translatable
+        switch (code) {
+            case InstallCallback.ERROR_TIMEOUT:
+                return "Timeout occured";
+
+            case InstallCallback.ERROR_SHELL_DIED:
+                return "Execution aborted unexpectedly";
+
+            case InstallCallback.ERROR_EXEC_FAILED:
+            case InstallCallback.ERROR_WRONG_UID:
+                return "Could not gain root access";
+
+            case InstallCallback.ERROR_INVALID_ZIP:
+                return "Not a flashable ZIP file";
+
+            case InstallCallback.ERROR_NOT_FLASHABLE_IN_APP:
+                return "This file can only be flashed via recovery";
+
+            default:
+                return "Error " + code + " occurred";
+        }
+    }
+
+    public static void triggerError(InstallCallback callback, int code) {
+        callback.onError(code, messageForError(code));
+    }
+
+    public static void closeSilently(ZipFile z) {
+        try {
+            z.close();
+        } catch (IOException ignored) {}
+    }
+
+    private InstallZipUtil() {}
+}


### PR DESCRIPTION
This is compatible with all flashable Xposed ZIPs, probably even with
unofficial ones. It obviously requires root access and a modifiable
/system partition. Systemless is still WIP and might need a few more
changes in the future.

If the interface is usable, other installation methods (auto/manual
flashing) could be re-implemented in the same way. Additionally, the
checks could be extended to check compatiblility with the current ROM.
