### PR TITLE
Fix crash on error when installing with root

### DIFF
--- a/app/src/main/java/de/robv/android/xposed/installer/util/InstallApkUtil.java
+++ b/app/src/main/java/de/robv/android/xposed/installer/util/InstallApkUtil.java
@@ -99,7 +99,7 @@ public class InstallApkUtil extends AsyncTask<Void, Void, Integer> {
             if (result.equals(0)) {
                 NotificationUtil.showModuleInstallNotification(R.string.installation_successful, R.string.installation_successful_message, info.localFilename, info.title);
             } else if (failureMatcher.find()) {
-                NotificationUtil.showModuleInstallNotification(R.string.installation_error, R.string.installation_error_message, info.localFilename, failureMatcher.group(1));
+                NotificationUtil.showModuleInstallNotification(R.string.installation_error, R.string.installation_error_message, info.localFilename, info.title, failureMatcher.group(1));
             }
         } else {
             installApkNormally(context, info.localFilename);


### PR DESCRIPTION
Missing argument

```
AndroidRuntime: FATAL EXCEPTION: main
AndroidRuntime: Process: de.robv.android.xposed.installer, PID: 13200
AndroidRuntime: java.util.MissingFormatArgumentException: Format specifier '%2$s'
AndroidRuntime:        at java.util.Formatter.format(Formatter.java)
AndroidRuntime:        at java.util.Formatter.format(Formatter.java)
AndroidRuntime:        at java.lang.String.format(String.java)
AndroidRuntime:        at android.content.res.Resources.getString(Resources.java)
AndroidRuntime:        at android.content.Context.getString(Context.java)
AndroidRuntime:        at de.robv.android.xposed.installer.util.NotificationUtil.showModuleInstallNotification(NotificationUtil.java:160)
AndroidRuntime:        at de.robv.android.xposed.installer.util.InstallApkUtil.onPostExecute(InstallApkUtil.java:102)
AndroidRuntime:        at de.robv.android.xposed.installer.util.InstallApkUtil.onPostExecute(InstallApkUtil.java:20)
AndroidRuntime:        at android.os.AsyncTask.finish(AsyncTask.java)
AndroidRuntime:        at android.os.AsyncTask.-wrap1(AsyncTask.java)
AndroidRuntime:        at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java)
AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java)
AndroidRuntime:        at android.os.Looper.loop(Looper.java)
AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java)
Method)
AndroidRuntime:        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java)
AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java)
AndroidRuntime:        at de.robv.android.xposed.XposedBridge.main(XposedBridge.java:107)
```
