### PR TITLE
Correcting the Redirect issue from HTTP to HTTPS.

### DIFF
--- a/app/src/main/java/de/robv/android/xposed/installer/util/RepoLoader.java
+++ b/app/src/main/java/de/robv/android/xposed/installer/util/RepoLoader.java
@@ -47,7 +47,7 @@ import de.robv.android.xposed.installer.util.DownloadsUtil.SyncDownloadInfo;
 
 public class RepoLoader {
     private static final int UPDATE_FREQUENCY = 24 * 60 * 60 * 1000;
-    private static final String DEFAULT_REPOSITORIES = "http://dl.xposed.info/repo/full.xml.gz";
+    private static final String DEFAULT_REPOSITORIES = "https://dl-xda.xposed.info/repo/full.xml.gz";
     private static RepoLoader mInstance = null;
     private final List<RepoListener> mListeners = new CopyOnWriteArrayList<>();
     private final Map<String, ReleaseType> mLocalReleaseTypesCache = new HashMap<>();


### PR DESCRIPTION
A fix to accommodate the changes made by @rovo89 whereas he had enforced HTTPS on the server, but the HttpURLConnection class used by the Xposed Installer has issues with following redirects from HTTP to HTTPS.

_If your pull request is a translation update, then the title of this pull must contains 'string' or 'translation'_
