### PR TITLE
Version Match with Rovo89...

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 16
         //noinspection OldTargetApi
         targetSdkVersion 25
-        versionCode 41
-        versionName "3.1.4 by dvdandroid - " + VERSION_DATE
+        versionCode 43
+        versionName "3.1.5 by dvdandroid - " + VERSION_DATE
         project.ext.set("archivesBaseName", "XposedInstaller_by_dvdandroid_" + VERSION_DATE.replaceAll("/", "_"))
 
         buildConfigField "String", "APP_VERSION", APP_VERSION


### PR DESCRIPTION
This is just a minor Version/Build bump to reflect Rovo89's latest XPosed Installer App Version 3.1.5 Build 43.

I had recently recalled your mentioning that you preferred to match the Version and Build to Rovo89's installer app. 

Thank you very much for your time, patience, support and understanding! :-) 


~Ibuprophen

_If your pull request is a translation update, then the title of this pull must contains 'string' or 'translation'_
