### PR TITLE
Remove proxy configuration from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,4 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Thu Jul 21 11:19:13 BST 2016
-systemProp.http.proxyHost=192.168.100.99
-systemProp.http.proxyPort=808
+


### PR DESCRIPTION
This should be in local.properties. This breaks sync if there is no proxy. [1]

[1] https://github.com/ElderDrivers/EdXposedManager/pull/46 by @aviraxp 